### PR TITLE
Add end-to-end tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,3 +51,4 @@ jobs:
         javac -Xdoclint:missing/private -Werror -cp "libraries:libraries/*:Project:Project/*" -d project-tests/Project\ Tests/bin/ Project/src/*.java project-tests/Project\ Tests/src/*.java
         cd project-tests/Project\ Tests
         java -cp "../../libraries/*" org.junit.platform.console.ConsoleLauncher -cp "bin/" --fail-if-no-tests --reports-dir="reports/" --details="tree" --select-class ${{ matrix.test }}
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run ${{ matrix.test }}
       run: |
         git clone https://github.com/usf-cs212-spring2020/project-tests.git
-        mkdir project-tests/Project\ Tests/src/binå
+        mkdir project-tests/Project\ Tests/src/bin
         javac -Xdoclint:missing/private -Werror -cp "libraries:libraries/*:Project:Project/*" -d project-tests/Project\ Tests/bin/ Project/src/*.java project-tests/Project\ Tests/src/*.java
         cd project-tests/Project\ Tests
         java -cp "../../libraries/*" org.junit.platform.console.ConsoleLauncher -cp "bin/" --fail-if-no-tests --reports-dir="reports/" --details="tree" --select-class ${{ matrix.test }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,57 @@
+
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request 
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  end-to-end:
+    strategy:
+      matrix:
+        test: [Project1Test, Project2Test]
+    runs-on: ubuntu-latest
+  # endToEnd tests
+
+    # The type of runner that the job will run on
+
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '13' # The JDK version to make available on the path.
+        java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+        architecture: x64 # (x64 or x86) - defaults to x64
+    - name: Set up libraries
+      run: |
+        mkdir libraries
+        cd libraries
+        curl -O https://repo1.maven.org/maven2/org/apache/opennlp/opennlp-tools/1.9.2/opennlp-tools-1.9.2.jar
+        curl -O https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.13.0/log4j-core-2.13.0.jar
+        curl -O https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.13.0/log4j-api-2.13.0.jar
+        curl -O https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.6.0-RC1/junit-platform-console-standalone-1.6.0-RC1.jar
+        curl -O https://repo1.maven.org/maven2/org/eclipse/jetty/aggregate/jetty-all/9.4.26.v20200117/jetty-all-9.4.26.v20200117-uber.jar
+        curl -O https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.8/commons-text-1.8.jar
+        curl -O https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar
+        curl https://repo1.maven.org/maven2/org/antlr/antlr4/4.7.2/antlr4-4.7.2-complete.jar > antlr-4.7.2-complete.jar
+        cd ..
+   # Runs a set of commands using the runners shell
+    - name: Run ${{ matrix.test }}
+      run: |
+        git clone https://github.com/usf-cs212-spring2020/project-tests.git
+        mkdir project-tests/Project\ Tests/src/binå
+        javac -Xdoclint:missing/private -Werror -cp "libraries:libraries/*:Project:Project/*" -d project-tests/Project\ Tests/bin/ Project/src/*.java project-tests/Project\ Tests/src/*.java
+        cd project-tests/Project\ Tests
+        java -cp "../../libraries/*" org.junit.platform.console.ConsoleLauncher -cp "bin/" --fail-if-no-tests --reports-dir="reports/" --details="tree" --select-class ${{ matrix.test }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,4 @@
-
-# This is a basic workflow to help you get started with Actions
-
+# Name of the workflow
 name: CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request 
@@ -20,9 +18,6 @@ jobs:
       matrix:
         test: [Project1Test, Project2Test]
     runs-on: ubuntu-latest
-  # endToEnd tests
-
-    # The type of runner that the job will run on
 
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -48,6 +43,7 @@ jobs:
         curl https://repo1.maven.org/maven2/org/antlr/antlr4/4.7.2/antlr4-4.7.2-complete.jar > antlr-4.7.2-complete.jar
         cd ..
    # Runs a set of commands using the runners shell
+   # Does this process for each test in matrix.test
     - name: Run ${{ matrix.test }}
       run: |
         git clone https://github.com/usf-cs212-spring2020/project-tests.git


### PR DESCRIPTION
This pull adds end-to-end testing capabilities to the template.

Currently, this has the Project1Test and the Project2Test options both running separately, as a matrix test.

In order to switch to only running Project1Tests, simply remove Project2Test from the "test" field within "matrix". 